### PR TITLE
modify gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,8 @@ log/
 # temp-file
 *rdb
 
-# 
+# idea
+.idea/
+
+# py
+*/__pycache__


### PR DESCRIPTION
1. master分支主要用于示例框架，没有实际案例，该分支用于在上面注册模型评估接口